### PR TITLE
cpan for centos 7

### DIFF
--- a/templates/_from-source-prereqs.html.ep
+++ b/templates/_from-source-prereqs.html.ep
@@ -46,7 +46,8 @@ sudo yum groupinstall 'Development Tools'</code></pre>
           <code>sudo yum install perl-ExtUtils-Command</code></p>
 
         <p class="suck-b">On CentOS 7, also run:
-          <code>sudo yum install perl-autodie</code></p>
+          <code>sudo yum install perl-autodie
+sudo yum install perl-CPAN</code></p>
       </div>
     </div>
   </div


### PR DESCRIPTION
`perl Configure.pl --backend=moar --gen-moar`

> ...
/usr/bin/perl tools/build/gen-version.pl /home/inter/rakudo/install /home/inter/rakudo/install/share/nqp/lib > gen/moar/stage1/nqp-config.nqp
Can't locate Digest/SHA.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at tools/build/gen-version.pl line 9.
BEGIN failed--compilation aborted at tools/build/gen-version.pl line 9.
make: *** [gen/moar/stage1/nqp.moarvm] Ошибка 2
Command failed (status 512): make
Command failed (status 512): /usr/bin/perl Configure.pl --prefix=/home/inter/rakudo/install --backends=moar --make-install

OS: CentOS Linux 7