### PR TITLE
Debian derivatives require libssl-dev

### DIFF
--- a/templates/_from-source-prereqs.html.ep
+++ b/templates/_from-source-prereqs.html.ep
@@ -20,7 +20,7 @@
       data-parent="#prepreqs-accordion">
       <div class="card-body">
         <p class="suck-b">Run:
-          <code>sudo apt-get install build-essential git</code></p>
+          <code>sudo apt-get install build-essential git libssl-dev</code></p>
       </div>
     </div>
   </div


### PR DESCRIPTION
On PureOS, which is a Debian derivative, the apt-get line proposed for Debian/Ubuntu did not include libssl-dev. Without it, the build will finish (warning about a missing libssl.so) and in the end, I cannot install `zef install --/test cro`, for example. Installing `libssl-dev` and running `make install` again fixed this (and requiring headers for `libssl` is mentioned in the introduction, so that part is correct and needs no fixing). 