### PR TITLE
Remove trailing slash in exported PATH

### DIFF
--- a/templates/files-rakudo-source.html.ep
+++ b/templates/files-rakudo-source.html.ep
@@ -50,7 +50,7 @@ make spectest
 
 make install
 
-echo "export PATH=$(pwd)/install/bin/:$(pwd)/install/share/perl6/site/bin:\$PATH" \\
+echo "export PATH=$(pwd)/install/bin:$(pwd)/install/share/perl6/site/bin:\$PATH" \\
     >> ~/.bashrc
 source ~/.bashrc</code></pre>
         <p>You'll likely want to also install


### PR DESCRIPTION
The instructions on building from source for Linux had a trailing slash in the exported `$PATH`, which made the output of `which` ugly:

```
$ which perl6    
/home/user/rakudo/install/bin//perl6
```

Although this is a purely cosmetic change, removing this trailing slash makes for less unexpected output.