### PR TITLE
Rakudo-Star: Add scoop as an alternative to chocolatey

### DIFF
--- a/templates/downloads.html.ep
+++ b/templates/downloads.html.ep
@@ -39,12 +39,21 @@
       </p>
       <a class="btn btn-dark kick-b" href="<%= url_for 'downloads-rakudo' %>">All releases</a>
 
-      <h4>Chocolatey Rakudo Star Bundle</h4>
+      <h4>Rakudo Star Bundle</h4>
 
       <p>This is a packaging of Rakudo itself, MoarVM, NQP and the modules of the Rakudo Star Bundle
-      It's built straight from the Rakudo Star Bundle Windows MSI usually released quarterly.
+      It's built straight from the Rakudo Star Bundle Windows MSI usually released quarterly.</p>
+      
+      <h5>Chocolatey</h5>
+      <p>Install the Rakudo Star Bundle with chocolatey:
       <code>choco install rakudostar</code></p>
       <a class="btn btn-dark" href="https://chocolatey.org/packages/rakudostar">Chocolatey</a>
+      
+      <h5>Scoop</h5>
+      <p>Install the Rakudo Star Bundle with scoop:
+      <code>scoop install rakudo-star</code></p>
+      <a class="btn btn-dark" href="https://scoop.sh/">Scoop</a>
+      
     </div>
 
     <input type="radio" id="download-tab-linux" name="tab-group-download">

--- a/templates/star-third-party.html.ep
+++ b/templates/star-third-party.html.ep
@@ -35,6 +35,20 @@
       </div>
     </div>
   </div>
+  
+    <div class="col-md-4">
+    <div class="card bg-dark">
+      <div class="card-body">
+        <h5 class="card-title">Scoop</h5>
+        <div class="card-text">
+          <p>To install, run: <br> <code>scoop install rakudo-star</code></p>
+          <a href="https://github.com/ScoopInstaller/Main/blob/master/bucket/rakudo-star.json"
+            class="btn btn-dark border-secondary">View scoop manifest</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  
   <div class="col-md-4">
     <div class="card bg-dark">
       <div class="card-body">

--- a/templates/star-third-party.html.ep
+++ b/templates/star-third-party.html.ep
@@ -35,7 +35,6 @@
       </div>
     </div>
   </div>
-  
     <div class="col-md-4">
     <div class="card bg-dark">
       <div class="card-body">
@@ -48,7 +47,6 @@
       </div>
     </div>
   </div>
-  
   <div class="col-md-4">
     <div class="card bg-dark">
       <div class="card-body">

--- a/templates/star-windows.html.ep
+++ b/templates/star-windows.html.ep
@@ -29,6 +29,10 @@
     <%== third_party 'Chocolatey',
       'https://chocolatey.org/packages/rakudostar' %>,
     run <code>choco install rakudostar</code> to install the Rakudo Star Bundle</li>
+      <li>If you prefer
+    <%== third_party 'Scoop',
+      'https://scoop.sh/' %>,
+    run <code>scoop install rakudo-star</code> to install the Rakudo Star Bundle</li>
   <li>For WSL (Windows Subsystem for Linux), you can install
     <a href="<%= url_for 'downloads-star-third-party' %>">pre-built 3<sup>rd</sup>
     party packages</a> or <a href="<%= url_for 'downloads-star-source' %>">build


### PR DESCRIPTION
add the scoop package manager as an alternative to the chocolatey installation instructions... 