### PR TITLE
Community page: Add link to #rakulang hashtag on Fediverse

### DIFF
--- a/templates/community.html.ep
+++ b/templates/community.html.ep
@@ -17,7 +17,8 @@
   <li><a href="https://twitter.com/raku_news">@raku_news Twitter feed</a></li>
   <li><a href="https://www.facebook.com/groups/raku.perl6/"><%== p6 %> Facebook
     group</a></li>
-  <li><a href="https://mastodon.sdf.org/tags/rakulang">#rakulang hashtag on the Fediverse</li>
+  <li><a href="https://mastodon.sdf.org/tags/rakulang">#rakulang on the Fediverse (Mastodon)</a>
+    and on <a href="https://bsky.app/search?q=%23rakulang">BlueSky</a></li>
   <li><a href="https://www.reddit.com/r/rakulang/">r/rakulang subreddit</a></li>
   <li><a href="https://stackoverflow.com/tags/raku/info"><%== p6 %>
     StackOverflow questions</a></li>


### PR DESCRIPTION
There's considerable activity on Mastodon revolving around the hashtag [#rakulang](https://mastodon.social/tags/rakulang). Since one has to pick one instance to link to (and since it's not healthy to point everyone to mastodon.social), I've picked mastodon.sdf.org for being hosted by a public organization and being somewhat related to technology.